### PR TITLE
List elimination

### DIFF
--- a/src/Analysis/Elaboration.hs
+++ b/src/Analysis/Elaboration.hs
@@ -63,12 +63,12 @@ elaborate (Fix (Cons h t)) = do
   t' <- check t (listT (tvar a))
   pure (listT (tvar a) :< Cons h' t')
 elaborate (Fix Nil) = (:< Nil) . listT . tvar <$> fresh
-elaborate (Fix (Uncons empty full list)) = do
+elaborate (Fix (Unlist empty full list)) = do
   a <- fresh
   empty' <- elaborate empty
   full' <- check full (tvar a .-> listT (tvar a) .-> extract empty')
   list' <- check list (listT (tvar a))
-  pure (extract empty' :< Uncons empty' full' list')
+  pure (extract empty' :< Unlist empty' full' list')
 
 check :: Term -> PartialType -> Elab PartialElabTerm
 check term ty = do

--- a/src/Analysis/Elaboration.hs
+++ b/src/Analysis/Elaboration.hs
@@ -96,4 +96,5 @@ bind name ty
   | Set.member name (freeTypeVariables ty) = pure (Pure (InfiniteType name ty))
   | otherwise                              = do
     subst <- get
-    maybe (modify (substExtend name (wrap ty)) >> pure (wrap ty)) (unify (wrap ty)) (substLookup name subst)
+    let ty' = substitute subst (wrap ty)
+    maybe (put (substExtend name ty' subst) >> pure ty') (unify ty') (substLookup name subst)

--- a/src/Analysis/Elaboration.hs
+++ b/src/Analysis/Elaboration.hs
@@ -63,6 +63,12 @@ elaborate (Fix (Cons h t)) = do
   t' <- check t (listT (tvar a))
   pure (listT (tvar a) :< Cons h' t')
 elaborate (Fix Nil) = (:< Nil) . listT . tvar <$> fresh
+elaborate (Fix (Uncons empty full list)) = do
+  a <- fresh
+  empty' <- elaborate empty
+  full' <- check full (tvar a .-> listT (tvar a) .-> extract empty')
+  list' <- check list (listT (tvar a))
+  pure (extract empty' :< Uncons empty' full' list')
 
 check :: Term -> PartialType -> Elab PartialElabTerm
 check term ty = do

--- a/src/Data/Expr.hs
+++ b/src/Data/Expr.hs
@@ -18,6 +18,7 @@ data Expr a
   | If a a a
   | Cons a a
   | Nil
+  | Uncons a a a
   deriving (Eq, Foldable, Functor, Generic1, Ord, Read, Show, Traversable)
 
 instance Eq1 Expr where liftEq = genericLiftEq
@@ -84,3 +85,6 @@ nil = Fix Nil
 
 list :: [Term] -> Term
 list = foldr cons nil
+
+uncons :: Term -> Term -> Term -> Term
+uncons empty full list = Fix (Uncons empty full list)

--- a/src/Data/Expr.hs
+++ b/src/Data/Expr.hs
@@ -18,7 +18,7 @@ data Expr a
   | If a a a
   | Cons a a
   | Nil
-  | Uncons a a a
+  | Unlist a a a
   deriving (Eq, Foldable, Functor, Generic1, Ord, Read, Show, Traversable)
 
 instance Eq1 Expr where liftEq = genericLiftEq
@@ -86,5 +86,5 @@ nil = Fix Nil
 list :: [Term] -> Term
 list = foldr cons nil
 
-uncons :: Term -> Term -> Term -> Term
-uncons empty full list = Fix (Uncons empty full list)
+unlist :: Term -> Term -> Term -> Term
+unlist empty full list = Fix (Unlist empty full list)

--- a/src/Data/Subst.hs
+++ b/src/Data/Subst.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFoldable, DeriveFunctor, DeriveTraversable, MultiParamTypeClasses, UndecidableInstances #-}
+{-# LANGUAGE DeriveFoldable, DeriveFunctor, DeriveTraversable, FlexibleInstances, MultiParamTypeClasses, UndecidableInstances #-}
 module Data.Subst where
 
 import Data.Bifunctor (second)
@@ -32,3 +32,6 @@ substExtend name value = (<> substSingleton name value)
 
 class Binder ty value where
   substitute :: Subst ty -> value -> value
+
+instance Binder ty ty => Binder ty (Subst ty) where
+  substitute subst = Subst . map (second (substitute subst)) . getSubst

--- a/src/Data/Subst.hs
+++ b/src/Data/Subst.hs
@@ -11,7 +11,7 @@ newtype Subst value = Subst { getSubst :: [(Name, value)] }
   deriving (Eq, Foldable, Functor, Ord, Read, Show, Traversable)
 
 instance Binder value value => Semigroup (Subst value) where
-  Subst s1 <> Subst s2 = Subst (List.unionBy ((==) `on` fst) (map (second (substitute (Subst s1))) s2) s1)
+  s1 <> s2 = Subst (List.unionBy ((==) `on` fst) (getSubst (substitute s1 s2)) (getSubst s1))
 
 instance Binder value value => Monoid (Subst value) where
   mempty = Subst []

--- a/src/Data/Subst.hs
+++ b/src/Data/Subst.hs
@@ -27,7 +27,7 @@ substSingleton :: Name -> value -> Subst value
 substSingleton name value = Subst [(name, value)]
 
 substExtend :: Binder value value => Name -> value -> Subst value -> Subst value
-substExtend name value = (<> substSingleton name value)
+substExtend name value = (substSingleton name value <>)
 
 
 class Binder ty value where


### PR DESCRIPTION
This PR adds a (non-recursive) primitive elimination form for lists:

```
unlist :: b - > (a -> [a] -> b) -> b
```

It also fixes unification & substitution (I think once and for all).