### PR TITLE
Total elaboration

### DIFF
--- a/complexity-analysis.cabal
+++ b/complexity-analysis.cabal
@@ -33,6 +33,7 @@ library
                      , mtl
                      , recursion-schemes
                      , these
+                     , transformers
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall -Werror -fno-warn-name-shadowing

--- a/src/Analysis/Elaboration.hs
+++ b/src/Analysis/Elaboration.hs
@@ -99,8 +99,8 @@ check term ty = do
 
 unify :: Monoid size => Rec (Sized Type) size -> Rec (Sized Type) size -> Elab size (Rec (Sized Type) size)
 unify (Rec (Sized s1 t1)) (Rec (Sized s2 t2))
-  | TVar name1 <- t1                   = bind name1 (Sized s2 t2)
-  |                   TVar name2 <- t2 = bind name2 (Sized s1 t1)
+  | TVar name1 <- t1                   = bind name1 (Rec (Sized s2 t2))
+  |                   TVar name2 <- t2 = bind name2 (Rec (Sized s1 t1))
   | ForAll{}   <- t1, ForAll{}   <- t2 = fresh >>= \ n -> makeForAllT n <$> unify (specialize t1 n) (specialize t2 n)
   | a1 :-> b1  <- t1, a2 :-> b2  <- t2 = (.->) <$> unify a1 a2 <*> unify b1 b2
   | a1 :*  b1  <- t1, a2 :*  b2  <- t2 = (.*)  <$> unify a1 a2 <*> unify b1 b2
@@ -109,13 +109,14 @@ unify (Rec (Sized s1 t1)) (Rec (Sized s2 t2))
   | List a1    <- t1, List a2    <- t2 = listT <$> unify a1 a2
   | otherwise                          = throwError (TypeMismatch (Rec (Sized s1 t1)) (Rec (Sized s2 t2)))
 
-bind :: Monoid size => Name -> Sized Type size (Rec (Sized Type) size) -> Elab size (Rec (Sized Type) size)
-bind name (Sized size ty)
-  | TVar name' <- ty, name == name'     = pure (fromType ty)
-  | Set.member name (freeVariables1 ty) = throwError (InfiniteType name (Rec (Sized size ty)))
-  | otherwise                           = do
+bind :: Monoid size => Name -> Rec (Sized Type) size -> Elab size (Rec (Sized Type) size)
+bind name ty
+  | TVar name' <- sizedType (unRec ty)
+  , name == name'                      = pure ty
+  | Set.member name (freeVariables ty) = throwError (InfiniteType name ty)
+  | otherwise                          = do
     subst <- get
-    let ty' = substitute subst (fromType ty)
+    let ty' = substitute subst ty
     maybe (put (substExtend name ty' subst) >> pure ty') (unify ty') (substLookup name subst)
 
 instance FreeVariables ty => FreeVariables (Error ty) where

--- a/src/Analysis/Elaboration.hs
+++ b/src/Analysis/Elaboration.hs
@@ -115,14 +115,13 @@ unify t1 t2 = do
           | otherwise                          = throwError (TypeMismatch r1 r2)
 
 bind :: Monoid size => Name -> Rec (Sized Type) size -> Elab size (Rec (Sized Type) size)
-bind name ty
-  | TVar name' <- sizedType (unRec ty)
-  , name == name'                      = pure ty
-  | Set.member name (freeVariables ty) = throwError (InfiniteType name ty)
-  | otherwise                          = do
+bind n ty
+  | TVar n' <- sizedType ty, n == n' = pure ty
+  | Set.member n (freeVariables ty)  = throwError (InfiniteType n ty)
+  | otherwise                        = do
     subst <- get
     let ty' = substitute subst ty
-    maybe (put (substExtend name ty' subst) >> pure ty') (unify ty') (substLookup name subst)
+    maybe (put (substExtend n ty' subst) >> pure ty') (unify ty') (substLookup n subst)
 
 instance FreeVariables ty => FreeVariables (Error ty) where
   freeVariables (FreeVariable _)     = mempty -- The free variable here is a term variable, not a type variable.

--- a/src/Analysis/Elaboration.hs
+++ b/src/Analysis/Elaboration.hs
@@ -31,70 +31,70 @@ runElab :: Elab size a -> Either (Error (Rec (Sized Type) size)) (a, Subst (Rec 
 runElab = fmap fst . runExcept . flip runFreshT (Name 0) . flip runReaderT (Context []) . flip runStateT mempty
 
 elaborate :: Semiring size => Term Expr -> Elab size (Rec (Ann Expr) (Rec (Sized Type) size))
-elaborate term = do
-  term' <- infer term
+elaborate tm = do
+  tm' <- infer tm
   subst <- get
-  let Rec (Ann ty tm) = substitute subst term'
-  pure (Rec (Ann (generalize ty) tm))
+  let Rec (Ann ty' tm'') = substitute subst tm'
+  pure (term (generalize ty') tm'')
 
 infer :: Semiring size => Term Expr -> Elab size (Rec (Ann Expr) (Rec (Sized Type) size))
 infer (Fix (Abs n b)) = do
   t <- fresh
   b' <- local (contextExtend n (tvar t)) (infer b)
-  pure (Rec (Ann (tvar t .-> ann b') (Abs n b')))
+  pure (term (tvar t .-> ann b') (Abs n b'))
 infer (Fix (Var name)) = do
   context <- ask
   case contextLookup name context of
-    Just ty -> pure (Rec (Ann ty (Var name)))
+    Just ty -> pure (term ty (Var name))
     Nothing -> throwError (FreeVariable name)
 infer (Fix (App f a)) = do
   t <- fresh
   a' <- infer a
   f' <- check f ((one <>) `modifySize` (ann a' .-> tvar t))
-  pure (Rec (Ann (tvar t) (App f' a')))
+  pure (term (tvar t) (App f' a'))
 infer (Fix (LetRec n b)) = do
   t <- fresh
   local (contextExtend n (tvar t)) (check b (tvar t))
-infer (Fix Expr.Unit) = pure (Rec (Ann unitT Expr.Unit))
+infer (Fix Expr.Unit) = pure (term unitT Expr.Unit)
 infer (Fix (Pair fst snd)) = do
   fst' <- infer fst
   snd' <- infer snd
-  pure (Rec (Ann (ann fst' .* ann snd') (Pair fst' snd')))
+  pure (term (ann fst' .* ann snd') (Pair fst' snd'))
 infer (Fix (Fst pair)) = do
   t1 <- fresh
   t2 <- fresh
   pair' <- check pair (tvar t1 .* tvar t2)
-  pure (Rec (Ann (tvar t1) (Fst pair')))
+  pure (term (tvar t1) (Fst pair'))
 infer (Fix (Snd pair)) = do
   t1 <- fresh
   t2 <- fresh
   pair' <- check pair (tvar t1 .* tvar t2)
-  pure (Rec (Ann (tvar t2) (Snd pair')))
+  pure (term (tvar t2) (Snd pair'))
 infer (Fix (Expr.Bool b)) = pure (Rec (Ann boolT (Expr.Bool b)))
 infer (Fix (If c t e)) = do
   c' <- check c boolT
   t' <- infer t
   e' <- infer e
   result <- unify (ann t') (ann e')
-  pure (Rec (Ann result (If c' t' e')))
+  pure (term result (If c' t' e'))
 infer (Fix (Cons h t)) = do
   a <- fresh
   h' <- check h (tvar a)
   t' <- check t (listT (tvar a))
-  pure (Rec (Ann (listT (tvar a)) (Cons h' t')))
-infer (Fix Nil) = Rec . flip Ann Nil . listT . tvar <$> fresh
+  pure (term (listT (tvar a)) (Cons h' t'))
+infer (Fix Nil) = flip term Nil . listT . tvar <$> fresh
 infer (Fix (Unlist empty full list)) = do
   a <- fresh
   empty' <- infer empty
   full' <- check full (tvar a .-> listT (tvar a) .-> ann empty')
   list' <- check list (listT (tvar a))
-  pure (Rec (Ann (ann empty') (Unlist empty' full' list')))
+  pure (term (ann empty') (Unlist empty' full' list'))
 
 check :: Semiring size => Term Expr -> Rec (Sized Type) size -> Elab size (Rec (Ann Expr) (Rec (Sized Type) size))
-check term ty = do
-  term' <- infer term
-  termTy <- unify (ann term') ty
-  pure (Rec (Ann termTy (expr term')))
+check tm ty = do
+  tm' <- infer tm
+  ty' <- unify (ann tm') ty
+  pure (term ty' (expr tm'))
 
 
 unify :: Monoid size => Rec (Sized Type) size -> Rec (Sized Type) size -> Elab size (Rec (Sized Type) size)

--- a/src/Analysis/Elaboration.hs
+++ b/src/Analysis/Elaboration.hs
@@ -103,16 +103,16 @@ unify t1 t2 = do
   ty <- go (substitute subst t1) (substitute subst t2)
   subst' <- get
   pure (substitute subst' ty)
-  where go (Rec (Sized s1 t1)) (Rec (Sized s2 t2))
-          | TVar name1 <- t1                   = bind name1 (Rec (Sized s2 t2))
-          |                   TVar name2 <- t2 = bind name2 (Rec (Sized s1 t1))
+  where go r1@(Rec (Sized _ t1)) r2@(Rec (Sized _ t2))
+          | TVar name1 <- t1                   = bind name1 r2
+          |                   TVar name2 <- t2 = bind name2 r1
           | ForAll{}   <- t1, ForAll{}   <- t2 = fresh >>= \ n -> makeForAllT n <$> unify (specialize t1 n) (specialize t2 n)
           | a1 :-> b1  <- t1, a2 :-> b2  <- t2 = (.->) <$> unify a1 a2 <*> unify b1 b2
           | a1 :*  b1  <- t1, a2 :*  b2  <- t2 = (.*)  <$> unify a1 a2 <*> unify b1 b2
           | Type.Unit  <- t1, Type.Unit  <- t2 = pure unitT
           | Type.Bool  <- t1, Type.Bool  <- t2 = pure boolT
           | List a1    <- t1, List a2    <- t2 = listT <$> unify a1 a2
-          | otherwise                          = throwError (TypeMismatch (Rec (Sized s1 t1)) (Rec (Sized s2 t2)))
+          | otherwise                          = throwError (TypeMismatch r1 r2)
 
 bind :: Monoid size => Name -> Rec (Sized Type) size -> Elab size (Rec (Sized Type) size)
 bind name ty

--- a/src/Analysis/Examples.hs
+++ b/src/Analysis/Examples.hs
@@ -1,12 +1,14 @@
+{-# LANGUAGE FlexibleContexts #-}
 module Analysis.Examples where
 
 import Data.Expr as Expr
+import Data.Functor.Foldable (Base, Recursive)
 import Data.Type as Type
 
 foldr :: Term Expr
 foldr = letRec (\ recur -> lam (\ combine -> lam (\ seed -> lam (\ list -> unlist seed (lam (\ a -> lam (\ as -> combine # a # (recur # combine # seed # as)))) list))))
 
-foldrT :: Total Type
+foldrT :: (Typical t, Typical1 (Base t), Recursive t) => t
 foldrT = forAllT (\ each -> forAllT (\ result -> (each .-> result .-> result) .-> result .-> listT each .-> result))
 
 -- $
@@ -17,7 +19,7 @@ foldrT = forAllT (\ each -> forAllT (\ result -> (each .-> result .-> result) .-
 map :: Term Expr
 map = letRec (\ recur -> lam (\ f -> lam (\ list -> unlist nil (lam (\ a -> lam (\ as -> cons (f # a) (recur # f # as)))) list)))
 
-mapT :: Total Type
+mapT :: (Typical t, Typical1 (Base t), Recursive t) => t
 mapT = forAllT (\ element -> forAllT (\ mapped -> (element .-> mapped) .-> listT element .-> listT mapped))
 
 -- $

--- a/src/Control/Monad/Fresh.hs
+++ b/src/Control/Monad/Fresh.hs
@@ -40,3 +40,6 @@ instance MonadFresh monad => MonadFresh (ReaderT read monad) where
 
 instance MonadFresh monad => MonadFresh (StateT state monad) where
   fresh = lift fresh
+
+instance MonadTrans FreshT where
+  lift m = FreshT (flip fmap m . flip (,))

--- a/src/Control/Monad/Fresh.hs
+++ b/src/Control/Monad/Fresh.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, UndecidableInstances #-}
 module Control.Monad.Fresh where
 
+import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
 import Data.Bifunctor (first)
@@ -43,3 +44,7 @@ instance MonadFresh monad => MonadFresh (StateT state monad) where
 
 instance MonadTrans FreshT where
   lift m = FreshT (flip fmap m . flip (,))
+
+instance MonadError error monad => MonadError error (FreshT monad) where
+  throwError = lift . throwError
+  catchError body handler = FreshT (\ s -> catchError (runFreshT body s) (flip runFreshT s . handler))

--- a/src/Data/Expr.hs
+++ b/src/Data/Expr.hs
@@ -45,9 +45,6 @@ ann (Rec (Ann ann _)) = ann
 expr :: Rec (Ann expr) ann -> expr (Rec (Ann expr) ann)
 expr (Rec (Ann _ expr)) = expr
 
-annF :: Ann expr ann recur -> ann
-annF (Ann ann _) = ann
-
 exprF :: Ann expr ann recur -> expr recur
 exprF (Ann _ expr) = expr
 

--- a/src/Data/Expr.hs
+++ b/src/Data/Expr.hs
@@ -42,6 +42,9 @@ instance (Show1 expr, Show ann) => Show1 (Ann expr ann) where liftShowsPrec = ge
 instance Functor expr => Bifunctor (Ann expr) where
   bimap f g (Ann ann expr) = Ann (f ann) (fmap g expr)
 
+term :: ann -> expr (Rec (Ann expr) ann) -> Rec (Ann expr) ann
+term ann expr = Rec (Ann ann expr)
+
 ann :: Rec (Ann expr) ann -> ann
 ann (Rec (Ann ann _)) = ann
 

--- a/src/Data/Expr.hs
+++ b/src/Data/Expr.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveFoldable, DeriveFunctor, DeriveGeneric, DeriveTraversable, FlexibleInstances, MultiParamTypeClasses, UndecidableInstances #-}
 module Data.Expr where
 
-import Data.Bifunctor (first)
+import Data.Bifunctor
 import Data.FreeVariables
 import Data.Functor.Classes.Generic
 import Data.Functor.Foldable (Fix(..), cata)
@@ -38,6 +38,9 @@ data Ann expr ann recur = Ann ann (expr recur)
 instance (Eq1   expr, Eq   ann) => Eq1   (Ann expr ann) where liftEq        = genericLiftEq
 instance (Ord1  expr, Ord  ann) => Ord1  (Ann expr ann) where liftCompare   = genericLiftCompare
 instance (Show1 expr, Show ann) => Show1 (Ann expr ann) where liftShowsPrec = genericLiftShowsPrec
+
+instance Functor expr => Bifunctor (Ann expr) where
+  bimap f g (Ann ann expr) = Ann (f ann) (fmap g expr)
 
 ann :: Rec (Ann expr) ann -> ann
 ann (Rec (Ann ann _)) = ann

--- a/src/Data/FreeVariables.hs
+++ b/src/Data/FreeVariables.hs
@@ -3,6 +3,7 @@ module Data.FreeVariables where
 
 import Data.Functor.Foldable (Fix(..))
 import Data.Name
+import Data.Rec
 import qualified Data.Set as Set
 
 class FreeVariables t where
@@ -23,3 +24,6 @@ instance FreeVariables1 Set.Set where
 
 instance FreeVariables1 ty => FreeVariables (Fix ty) where
   freeVariables (Fix ty) = freeVariables1 ty
+
+instance FreeVariables1 (ty size) => FreeVariables (Rec ty size) where
+  freeVariables = freeVariables1 . unRec

--- a/src/Data/Type.hs
+++ b/src/Data/Type.hs
@@ -143,6 +143,10 @@ instance Monoid size => Typical1 (Sized Type size) where
   toType1 = Just . sizedType
 
 
+instance Typical1 (ty size) => Typical (Rec ty size) where
+  fromType = Rec . fromType1
+  toType = toType1 . unRec
+
 instance Typical1 ty => Typical (Total ty) where
   fromType = Fix . fromType1
   toType = toType1 . unfix

--- a/src/Data/Type.hs
+++ b/src/Data/Type.hs
@@ -68,11 +68,14 @@ data Sized ty size recur = Sized size (ty recur)
 size :: Sized ty size recur -> size
 size (Sized size _) = size
 
-sizedType :: Sized ty size recur -> ty recur
-sizedType (Sized _ ty) = ty
+sizedType :: Rec (Sized ty) size -> ty (Rec (Sized ty) size)
+sizedType = sizedTypeF . unRec
+
+sizedTypeF :: Sized ty size recur -> ty recur
+sizedTypeF (Sized _ ty) = ty
 
 eraseSize :: (Recursive t, Base t ~ Sized ty size, Functor ty) => t -> Total ty
-eraseSize = cata (Fix . sizedType)
+eraseSize = cata (Fix . sizedTypeF)
 
 instance (Eq1   ty, Eq   size) => Eq1   (Sized ty size) where liftEq        = genericLiftEq
 instance (Ord1  ty, Ord  size) => Ord1  (Sized ty size) where liftCompare   = genericLiftCompare
@@ -139,7 +142,7 @@ instance Typical1 Type where
 
 instance Monoid size => Typical1 (Sized Type size) where
   fromType1 = Sized mempty
-  toType1 = Just . sizedType
+  toType1 = Just . sizedTypeF
 
 
 instance Typical1 (ty size) => Typical (Rec ty size) where

--- a/src/Data/Type.hs
+++ b/src/Data/Type.hs
@@ -28,12 +28,6 @@ instance Eq1   Type where liftEq        = genericLiftEq
 instance Ord1  Type where liftCompare   = genericLiftCompare
 instance Show1 Type where liftShowsPrec = genericLiftShowsPrec
 
-data Error
-  = FreeVariable Name
-  | TypeMismatch (Total Type) (Total Type)
-  | InfiniteType Name (Total Type)
-  deriving (Eq, Ord, Show)
-
 
 type Total = Fix
 
@@ -209,11 +203,6 @@ instance FreeVariables1 Type where
   liftFreeVariables _     (TVar name)        = Set.singleton name
   liftFreeVariables recur (ForAll name body) = Set.delete name (recur body)
   liftFreeVariables recur ty                 = foldMap recur ty
-
-instance FreeVariables Error where
-  freeVariables (FreeVariable _)     = mempty -- The free variable here is a term variable, not a type variable.
-  freeVariables (TypeMismatch t1 t2) = freeVariables t1 `mappend` freeVariables t2
-  freeVariables (InfiniteType n b)   = Set.insert n (freeVariables b)
 
 instance FreeVariables1 ty => FreeVariables1 (Sized ty size) where
   liftFreeVariables recur (Sized _ ty) = liftFreeVariables recur ty

--- a/src/Data/Type.hs
+++ b/src/Data/Type.hs
@@ -235,7 +235,7 @@ instance Substitutable1 ty functor => Substitutable1 ty (Sized functor size) whe
   liftSubstitute recur subst (Sized size ty) = first (Sized size) (liftSubstitute recur subst ty)
 
 instance Substitutable1 (Rec (Sized ty) size) ty => Substitutable (Rec (Sized ty) size) (Rec (Sized ty) size) where
-  substitute subst (Rec (Sized size ty)) = either (const (Rec (Sized size ty))) id (liftSubstitute substitute subst ty)
+  substitute subst (Rec (Sized size ty)) = either (Rec . Sized size) id (liftSubstitute substitute subst ty)
 
 
 -- $setup

--- a/src/Data/Type.hs
+++ b/src/Data/Type.hs
@@ -70,6 +70,9 @@ size (Sized size _) = size
 sizedType :: Sized ty size recur -> ty recur
 sizedType (Sized _ ty) = ty
 
+eraseSize :: (Recursive t, Base t ~ Sized ty size, Functor ty) => t -> Total ty
+eraseSize = cata (Fix . sizedType)
+
 instance (Eq1   ty, Eq   size) => Eq1   (Sized ty size) where liftEq        = genericLiftEq
 instance (Ord1  ty, Ord  size) => Ord1  (Sized ty size) where liftCompare   = genericLiftCompare
 instance (Show1 ty, Show size) => Show1 (Sized ty size) where liftShowsPrec = genericLiftShowsPrec

--- a/src/Data/Type.hs
+++ b/src/Data/Type.hs
@@ -82,9 +82,8 @@ instance Functor ty => Bifunctor (Sized ty) where
   bimap f g (Sized size ty) = Sized (f size) (fmap g ty)
 
 
-modifySize :: Functor ty => (size -> size) -> Partial error (Sized ty size) -> Partial error (Sized ty size)
-modifySize f (Cont sized) = Cont (first f sized)
-modifySize _ other        = other
+modifySize :: Functor ty => (size -> size) -> Rec (Sized ty) size -> Rec (Sized ty) size
+modifySize f (Rec sized) = Rec (first f sized)
 
 
 totalToPartial :: Typical1 ty => Total Type -> Partial error ty

--- a/src/Data/Type.hs
+++ b/src/Data/Type.hs
@@ -7,6 +7,7 @@ import Data.Functor.Classes
 import Data.Functor.Classes.Generic
 import Data.Functor.Foldable (Base, Fix(..), Recursive(..), unfix)
 import Data.Name
+import Data.Rec
 import qualified Data.Set as Set
 import Data.Subst
 import GHC.Generics
@@ -226,6 +227,9 @@ instance Substitutable1 (Partial error ty) ty => Substitutable (Partial error ty
 
 instance Substitutable1 ty functor => Substitutable1 ty (Sized functor size) where
   liftSubstitute recur subst (Sized size ty) = first (Sized size) (liftSubstitute recur subst ty)
+
+instance Substitutable1 (Rec (Sized ty) size) ty => Substitutable (Rec (Sized ty) size) (Rec (Sized ty) size) where
+  substitute subst (Rec (Sized size ty)) = either (const (Rec (Sized size ty))) id (liftSubstitute substitute subst ty)
 
 
 -- $setup


### PR DESCRIPTION
This PR gets rid of the `Partial` datatype, throwing errors instead of e.g. trying to perform partial unification.